### PR TITLE
Disable SpringBoot JDBC session auto configuration

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -92,10 +92,6 @@
       <version>${spring.boot.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.springframework.session</groupId>
-      <artifactId>spring-session-jdbc</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>


### PR DESCRIPTION
In order to remove the SpringBoot auto configuration "magic", the dependency had to be removed.

SpringBoot often triggers the auto configuration when finding certain classes in the classpath. This behaviour can be checked if DEBUG logs are enabled.

We will get rid off the spammy spring-jdbc-session logs this way.