### PR TITLE
Fix/Multiple sessions support

### DIFF
--- a/backend/src/main/java/com/huellapositiva/infrastructure/security/JwtService.java
+++ b/backend/src/main/java/com/huellapositiva/infrastructure/security/JwtService.java
@@ -67,7 +67,8 @@ public class JwtService {
             throw new InvalidJwtTokenException("Unable to decode token: " + token, e);
         }
 
-        if (isRevoked(decodedJWT)) {
+        boolean isRefresh = decodedJWT.getClaim(ROLE_CLAIM).asList(String.class).isEmpty();
+        if (!isRefresh && isRevoked(decodedJWT)) {
             log.warn("Token is revoked: {}, {}, {}", decodedJWT.getSubject(), decodedJWT.getIssuedAt(), revokedAccessTokens.get(decodedJWT.getSubject()));
             throw new InvalidJwtTokenException("Token is revoked: " + token);
         }

--- a/backend/src/test/java/com/huellapositiva/util/TestUtils.java
+++ b/backend/src/test/java/com/huellapositiva/util/TestUtils.java
@@ -2,6 +2,7 @@ package com.huellapositiva.util;
 
 import com.huellapositiva.domain.Roles;
 import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -10,8 +11,10 @@ import org.springframework.test.web.servlet.ResultMatcher;
 
 import java.util.Collections;
 
+import static org.springframework.http.MediaType.APPLICATION_JSON;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public final class TestUtils {
 
@@ -40,5 +43,25 @@ public final class TestUtils {
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(expectedResult)
                 .andExpect(expectedHeader);
+    }
+
+    public static MockHttpServletResponse loginRequest(MockMvc mvc, String body) throws Exception {
+        return mvc.perform(post("/api/v1/volunteers/login")
+                .content(body)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
+    }
+
+    public static MockHttpServletResponse refreshRequest(MockMvc mvc, String token) throws Exception {
+        return mvc.perform(post("/api/v1/refresh")
+                .content(token)
+                .contentType(APPLICATION_JSON)
+                .accept(APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse();
     }
 }


### PR DESCRIPTION
Refresh Token is now able to create new Access Tokens when the old Access Token was revoked.
It only affected when a user was logged in several sessions