### PR TITLE
:adhesive_bandage: Changed CSRF configuration

### DIFF
--- a/backend/src/main/java/com/huellapositiva/infrastructure/SecurityConfig.java
+++ b/backend/src/main/java/com/huellapositiva/infrastructure/SecurityConfig.java
@@ -73,7 +73,7 @@ class SecurityConfig extends WebSecurityConfigurerAdapter {
         http.cors().and()
                 .csrf()
                 .ignoringAntMatchers("/api/v1/authentication/login", "/api/v1/volunteers", "/api/v1/contactperson")
-                .csrfTokenRepository(new CookieCsrfTokenRepository())
+                .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
                 .and().authorizeRequests()
                 .requestMatchers(AUTH_ALLOWSLIST).permitAll()
                 .anyRequest().authenticated()


### PR DESCRIPTION
### CSRF fix

Based on this [ documentation ](https://owasp.org/www-community/attacks/csrf#:~:text=Cross%2DSite%20Request%20Forgery%20(CSRF,which%20they're%20currently%20authenticated ) and the need of the front-end library used for querying the back end for this XSRF-TOKEN cookie to be accesible from JavaScriopt, I suggest changing this Security configuration.