### PR TITLE
Feature/change enrollment closed proposal to published

### DIFF
--- a/backend/src/main/java/com/huellapositiva/application/controller/ProposalApiController.java
+++ b/backend/src/main/java/com/huellapositiva/application/controller/ProposalApiController.java
@@ -68,6 +68,8 @@ public class ProposalApiController {
 
     private final ChangeReviewPendingProposalToPublishedAction changeReviewPendingProposalToPublishedAction;
 
+    private final ChangeEnrollmentClosedProposalToPublishedAction changeEnrollmentClosedProposalToPublishedAction;
+
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Operation(
@@ -538,11 +540,43 @@ public class ProposalApiController {
                     )
             }
     )
-    @PutMapping("/publish")
+    @PutMapping("/publish/review-pending")
     @RolesAllowed("REVISER")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void changeReviewPendingProposalToPublished(@RequestBody ChangeStatusProposalRequestDto dto) {
         changeReviewPendingProposalToPublishedAction.execute(dto.getIdProposal());
+    }
+
+
+    @Operation(
+            summary = "Updates the proposal status to PUBLISHED",
+            description = "The contact person can update the proposal status from ENROLLMENT_CLOSED to PUBLISHED.",
+            tags = {"proposals, contact person"},
+            parameters = {
+                    @Parameter(name = "X-XSRF-TOKEN", in = ParameterIn.HEADER, required = true, example = "ff79038b-3fec-41f0-bab8-6e0d11db986e", description = "For taking this value, open your inspector code on your browser, and take the value of the cookie with the name 'XSRF-TOKEN'. Example: a6f5086d-af6b-464f-988b-7a604e46062b"),
+                    @Parameter(name = "XSRF-TOKEN", in = ParameterIn.COOKIE, required = true, example = "ff79038b-3fec-41f0-bab8-6e0d11db986e", description = "Same value of X-XSRF-TOKEN")
+            },
+            security = {
+                    @SecurityRequirement(name = "accessToken")
+            }
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "204",
+                            description = "No Content, proposal status changed to PUBLISHED successfully."
+                    ),
+                    @ApiResponse(
+                            responseCode = "409",
+                            description = "The proposal status in database is not ENROLLMENT_CLOSE."
+                    )
+            }
+    )
+    @PutMapping("/publish/enrollment-closed")
+    @RolesAllowed("CONTACT_PERSON")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void changeEnrollmentClosedProposalToPublished(@RequestBody ChangeStatusProposalRequestDto dto) {
+        changeEnrollmentClosedProposalToPublishedAction.execute(dto.getIdProposal());
     }
 }
 

--- a/backend/src/main/java/com/huellapositiva/domain/actions/ChangeEnrollmentClosedProposalToPublishedAction.java
+++ b/backend/src/main/java/com/huellapositiva/domain/actions/ChangeEnrollmentClosedProposalToPublishedAction.java
@@ -1,0 +1,21 @@
+package com.huellapositiva.domain.actions;
+
+import com.huellapositiva.domain.service.ProposalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChangeEnrollmentClosedProposalToPublishedAction {
+
+    private final ProposalService proposalService;
+
+    /**
+     * Method for update status proposal to published from enrollment closed.
+     *
+     * @param idProposal : The ID of the proposal.
+     */
+    public void execute(String idProposal) {
+        proposalService.changeStatusToPublishedFromEnrollmentClosed(idProposal);
+    }
+}

--- a/backend/src/main/java/com/huellapositiva/domain/service/ProposalService.java
+++ b/backend/src/main/java/com/huellapositiva/domain/service/ProposalService.java
@@ -139,4 +139,23 @@ public class ProposalService {
         JpaContactPerson contactPerson = jpaContactPersonRepository.findByEsalId(esalId).orElseThrow(EntityNotFoundException::new);
         return new ChangeStatusToPublishedResult(contactPerson.getCredential().getEmail(), proposal.getTitle());
     }
+
+    /**
+     * Publish proposal if the proposal have status ENROLLMENT_CLOSED.
+     * @param idProposal : The id of the proposal to be checked and updated.
+     * @throws - ProposalNotPublishableException
+     */
+    public void changeStatusToPublishedFromEnrollmentClosed(String idProposal) {
+        JpaProposal proposal = jpaProposalRepository.findByNaturalId(idProposal).orElseThrow(EntityNotFoundException::new);
+        String status = proposal.getStatus().getName().toUpperCase();
+
+        if (!ENROLLMENT_CLOSED.toString().equals(status)) {
+            throw new ProposalNotPublishableException();
+        }
+
+        JpaProposalStatus jpaProposalStatus = JpaProposalStatus.builder()
+                .id(ProposalStatus.PUBLISHED.getId())
+                .name("PUBLISHED").build();
+        jpaProposalRepository.updateStatusById(idProposal, jpaProposalStatus);
+    }
 }


### PR DESCRIPTION
The contact person now can change the enrollment_closed proposal status to published.
We have doubts about the endpoint naming because we already have /publish endpoint. We think that we could add the expected status thus: /publish/enrollment-closed