### PR TITLE
Publish 'beta' docker tags to keep compatibility with existing env

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -21,9 +21,8 @@ def buildAndPublishDockerImages(String nextReleaseNumber='') {
     docker.withRegistry('', 'docker-token') {
         def customImage = docker.build("${env.DOCKER_ORGANIZATION}/huelladigital-backend:${nextReleaseNumber}", '--pull --no-cache backend')
         customImage.push()
-        if (nextReleaseNumber != 'beta') {
-            customImage.push('latest')
-        }
+        customImage.push('beta') // Leave for compatibility with default deployment environment
+        customImage.push('latest')
     }
 }
 


### PR DESCRIPTION
After merging the changes for the AWS migration we stopped publishing 'beta' docker tags of the backend service.

This may have the side effect of not updating the backend component on the original deployment environment.